### PR TITLE
Using throw functions instead of fatalError for Server Start and Stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,36 @@ Then run `swift build` whenever you get prepared.
 
 ## Code
 
+Starting the server:
+
 ```swift
 let uploader = SwiftyUploader()
-uploader.run()
+
+DispatchQueue.global().async {
+    do {
+        try uploader.run()
+    } catch {
+        DispatchQueue.main.async {
+            print("Failed to start server: \(error)")
+        }
+        return
+    }
+}
+```
+
+Stopping the server:
+
+```swift
+DispatchQueue.global().async {
+    do {
+        try uploader.stop()
+    } catch {
+        DispatchQueue.main.async {
+            print("Failed to stop server: \(error)")
+        }
+        return
+    }
+}
 ```
 
 If you need web page support for international languages, you need to add the following settings in the app's info.plist

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -43,9 +43,36 @@ Then run `swift build` whenever you get prepared.
 
 ## 代码
 
+启动服务器:
+
 ```swift
 let uploader = SwiftyUploader()
-uploader.run()
+
+DispatchQueue.global().async {
+    do {
+        try uploader.run()
+    } catch {
+        DispatchQueue.main.async {
+            print("Failed to start server: \(error)")
+        }
+        return
+    }
+}
+```
+
+停止服务器:
+
+```swift
+DispatchQueue.global().async {
+    do {
+        try uploader.stop()
+    } catch {
+        DispatchQueue.main.async {
+            print("Failed to stop server: \(error)")
+        }
+        return
+    }
+}
 ```
 
 如果你需要 web 界面支持自适应的国际化语言，需要在 app 的 info.plist中增加下面的设置


### PR DESCRIPTION
### Feature: Using throw functions instead of `fatalError` for Server Start and Stop

#### Description:
This pull request modifies the `run()` and `stop()` functions to use throwing functions, allowing for proper error handling. The code now utilizes `DispatchQueue.global().async` to handle the server's start and stop procedures, giving a more flexible and robust control flow. The README has also been updated to reflect these changes.

#### Changes:
- Modified `run()` to use a throwing function instead of `fatalError`, wrapped in an asynchronous call.
- Updated `stop()` to use a similar pattern.
- Revised README to include the new code snippets for starting and stopping the server.

#### Breaking Changes:
- The way the server is started and stopped has changed, requiring the use of asynchronous error-handling constructs.

#### Testing:
- Ensure the server starts and stops correctly using the updated functions.
- Review the README for correctness and clarity.

Please review and provide feedback.