### PR TITLE
feat: random port while port is in use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,36 +41,14 @@ Then run `swift build` whenever you get prepared.
 
 ## Code
 
-Starting the server:
-
 ```swift
 let uploader = SwiftyUploader()
 
-DispatchQueue.global().async {
-    do {
-        try uploader.run()
-    } catch {
-        DispatchQueue.main.async {
-            print("Failed to start server: \(error)")
-        }
-        return
-    }
-}
-```
+// Starting the server:
+uploader.run()
 
-Stopping the server:
-
-```swift
-DispatchQueue.global().async {
-    do {
-        try uploader.stop()
-    } catch {
-        DispatchQueue.main.async {
-            print("Failed to stop server: \(error)")
-        }
-        return
-    }
-}
+// Stopping the server:
+uploader.stop()
 ```
 
 If you need web page support for international languages, you need to add the following settings in the app's info.plist

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -43,36 +43,14 @@ Then run `swift build` whenever you get prepared.
 
 ## 代码
 
-启动服务器:
-
 ```swift
 let uploader = SwiftyUploader()
 
-DispatchQueue.global().async {
-    do {
-        try uploader.run()
-    } catch {
-        DispatchQueue.main.async {
-            print("Failed to start server: \(error)")
-        }
-        return
-    }
-}
-```
+// 启动服务器
+uploader.run()
 
-停止服务器:
-
-```swift
-DispatchQueue.global().async {
-    do {
-        try uploader.stop()
-    } catch {
-        DispatchQueue.main.async {
-            print("Failed to stop server: \(error)")
-        }
-        return
-    }
-}
+// 停止服务器
+uploader.stop()
 ```
 
 如果你需要 web 界面支持自适应的国际化语言，需要在 app 的 info.plist中增加下面的设置


### PR DESCRIPTION
**Title**: Enhancements to SwiftyUploader: Port Retrieval, Address Formatting and Dynamic Port Selection

---

**Description**:

This pull request introduces several enhancements to the `SwiftyUploader` class:

1. **Port Retrieval**: A new function `getPort()` has been added to retrieve the current port being used.
2. **Address Formatting**: Updated the `getIPAddress()` function to return the address inclusive of the port, if it's not 80.
3. **Dynamic Port Selection**: In the event of the default port being occupied, the class now automatically picks a random available port.

---

- Enhanced `getAvailablePort(using:)` to dynamically pick a random port in case the default or current port is already in use.
```swift
while true {
    do {
        let channel = try bootstrap.bind(host: "0.0.0.0", port: currentPort).wait()
        channel.close(mode: .all, promise: nil)
        return currentPort
    } catch let error as IOError where error.errnoCode == EADDRINUSE {
        currentPort = Int.random(in: 1025...65535)
    }
}
```

**Changes**:

- Added `getPort()` function to `SwiftyUploader` which returns the current port being used.
```swift
public func getPort() -> Int {
    return self.port
}
```

- Updated `getIPAddress()` function to concatenate port if it's not the default HTTP port (80).
```swift
if let address = address {
    if port != 80 {
        return "\(address):\(port)"
    }
    return address
} else {
    return ""
}
```

---

**Test Cases**:

1. Start the SwiftyUploader and call `getPort()`, ensuring it returns the current port.
2. Call `getIPAddress()` and validate:
   - If the port is 80, only the IP address is returned.
   - If the port is not 80, the result should be in the format `IP:Port`.
3. If port 80 is already in use, start the SwiftyUploader and ensure it picks a random port and starts without any issues.

---

**Type of change**:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

notes: server run and stop functions has reverted.

Please review the changes and provide feedback.